### PR TITLE
Simplify Pipe interface - now pipe just takes a fn

### DIFF
--- a/gopipe_example_test.go
+++ b/gopipe_example_test.go
@@ -16,7 +16,7 @@ func ExamplePipeline() {
 	pipeinput := intGenerator(max)
 	pipeline.AttachSource(pipeinput)
 
-	for i := 0; i < max; i += 1 {
+	for i := 0; i < max; i++ {
 		fmt.Printf("value is: %d\n", pipeline.Dequeue())
 	}
 	// Output:
@@ -39,7 +39,7 @@ func ExampleEnqueue() {
 		pipeline.Enqueue(i)
 	}
 
-	for i := 0; i < max-1; i += 1 {
+	for i := 0; i < max-1; i++ {
 		fmt.Printf("value is: %d\n", pipeline.Dequeue())
 	}
 	fmt.Printf("Dequeue valid with timeout: %v\n", pipeline.DequeueTimeout(1*time.Millisecond))

--- a/gopipe_stubs_for_test.go
+++ b/gopipe_stubs_for_test.go
@@ -6,26 +6,22 @@ import (
 
 type doublingPipe struct{}
 
-func (dp doublingPipe) Process(in chan interface{}, out chan interface{}) {
-	for item := range in {
-		if intval, ok := item.(int); ok {
-			out <- intval * 2
-		} else {
-			log.Println("not ok")
-		}
+func (dp doublingPipe) Process(in interface{}) (interface{}, bool) {
+	if intval, ok := in.(int); ok {
+		return intval * 2, true
 	}
+	log.Println("not ok")
+	return nil, false
 }
 
 type subtractingPipe struct{}
 
-func (sp subtractingPipe) Process(in chan interface{}, out chan interface{}) {
-	for item := range in {
-		if intval, ok := item.(int); ok {
-			out <- intval - 1
-		} else {
-			log.Println("not ok")
-		}
+func (sp subtractingPipe) Process(in interface{}) (interface{}, bool) {
+	if intval, ok := in.(int); ok {
+		return intval - 1, true
 	}
+	log.Println("not ok")
+	return nil, false
 }
 
 func intGenerator(limit int) (out chan interface{}) {
@@ -41,14 +37,12 @@ func intGenerator(limit int) (out chan interface{}) {
 
 type pluralizingPipe struct{}
 
-func (pp pluralizingPipe) Process(in chan interface{}, out chan interface{}) {
-	for item := range in {
-		if strVal, ok := item.(string); ok {
-			out <- strVal + "s"
-		} else {
-			log.Println("non-string input")
-		}
+func (pp pluralizingPipe) Process(in interface{}) (interface{}, bool) {
+	if strVal, ok := in.(string); ok {
+		return strVal + "s", true
 	}
+	log.Println("non-string input")
+	return nil, false
 }
 
 func animalGenerator(limit int) (out chan interface{}) {

--- a/gopipe_test.go
+++ b/gopipe_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Pipeline", func() {
 				pipeout := make(chan interface{})
 				pipeline.AttachSink(pipeout)
 
-				for start := 0; start < max; start += 1 {
+				for start := 0; start < max; start++ {
 					outVal := <-pipeout
 					Expect(outVal).To(Equal((start * 2) - 1))
 				}
@@ -71,7 +71,7 @@ var _ = Describe("Pipeline", func() {
 					}
 					return "", nil
 				})
-				for start := 0; start < max; start += 1 {
+				for start := 0; start < max; start++ {
 					select {
 					case val, more := <-fanout["dogs"]:
 						if !more {
@@ -126,7 +126,7 @@ var _ = Describe("Pipeline", func() {
 					}
 					return "", nil
 				})
-				for start := 0; start < max; start += 1 {
+				for start := 0; start < max; start++ {
 					select {
 					case val, more := <-fanout["dogs"]:
 						if !more {
@@ -174,7 +174,7 @@ var _ = Describe("Pipeline", func() {
 				pipeout := make(chan interface{})
 				pipeline.AttachSink(pipeout)
 
-				for start := 0; start < max; start += 1 {
+				for start := 0; start < max; start++ {
 					outVal := <-pipeout
 					tapVal := <-tapOut
 					Expect(outVal).To(Equal(tapVal))
@@ -314,7 +314,7 @@ var _ = Describe("Pipeline", func() {
 					pipeout := make(chan interface{})
 					pipeline.AttachSink(pipeout)
 
-					for start := 0; start < max; start += 1 {
+					for start := 0; start < max; start++ {
 						Expect(<-pipeout).To(Equal((start * 2) - 1))
 					}
 				})


### PR DESCRIPTION
Any function can sort of be converted into a Pipe by either
implementing the interface directly or just wrapping it in a func
that returns an `out interface{}, next bool` pair.
If `next` is true, `out` is forwarded down the pipe, otherwise it
is skipped.